### PR TITLE
Replaced name of the function

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ function custom_settings_page() { ?>
 <?php }
 
 function custom_settings_add_menu() {
-	add_menu_page( 'Custom Settings', 'Custom Settings', 'manage_options', 'custom-settings', 'custom_settings_page', null, 99 );
+	add_theme_page( 'Custom Settings', 'Custom Settings', 'manage_options', 'custom-settings', 'custom_settings_page', null, 99 );
 }
 add_action( 'admin_menu', 'custom_settings_add_menu' );
 


### PR DESCRIPTION
In the Wordpress Theme Directory themes are required to use `add_theme_page()`.
By using `add_menu_page` we getting an error ( "REQUIRED" ).
This problem existing for a long [time](http://wordpress.stackexchange.com/questions/127738/add-sub-menu-page-to-be-replaced-by-add-theme-page).