### PR TITLE
Update jQuery function

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,13 +745,12 @@ add_filter( 'script_loader_src', 'remove_cssjs_ver', 10, 2 );
 /**
  * modify jquery
  */
-add_action( 'init', 'modify_jquery' );
 function modify_jquery() {
     wp_deregister_script('jquery');
-    wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js', false, null);
+    wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js', false, '3.2.1');
     wp_enqueue_script('jquery');
 }
-if (!is_admin()) add_action('wp_enqueue_scripts', 'modify_jquery', 11);
+if (!is_admin()) add_action('wp_enqueue_scripts', 'modify_jquery');
 ```
 
 ##  Disable Website Field From Comment Form

--- a/README.md
+++ b/README.md
@@ -745,16 +745,13 @@ add_filter( 'script_loader_src', 'remove_cssjs_ver', 10, 2 );
 /**
  * modify jquery
  */
-function modify_jquery() {
-    if ( !is_admin() && !is_login_page() ) {
-        // comment out the next two lines to load the local copy of jQuery
-        wp_deregister_script('jquery');
-        // wp_register_script('jquery', 'https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js', false, '2.2.4');
-        wp_register_script('jquery', 'https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js', false, '3.2.1');
-        wp_enqueue_script('jquery');
-    }
-}
 add_action( 'init', 'modify_jquery' );
+function modify_jquery() {
+    wp_deregister_script('jquery');
+    wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js', false, null);
+    wp_enqueue_script('jquery');
+}
+if (!is_admin()) add_action('wp_enqueue_scripts', 'modify_jquery', 11);
 ```
 
 ##  Disable Website Field From Comment Form

--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ add_filter( 'script_loader_src', 'remove_cssjs_ver', 10, 2 );
  */
 function modify_jquery() {
     wp_deregister_script('jquery');
-    wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js', false, '3.2.1');
+    wp_register_script('jquery', 'https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js', false, '3.2.1');
     wp_enqueue_script('jquery');
 }
 if (!is_admin()) add_action('wp_enqueue_scripts', 'modify_jquery');


### PR DESCRIPTION
`is_login_page()` doesn't seems to be a native Wordpress function, so I got an error when using the current version of the modify_jquery function. 

As I understand using `wp_enqueue_scripts` is the right way to add scripts/styles to the front-end, so here's a pull request which uses that instead. It might help someone else.

Read more here:
https://make.wordpress.org/core/2011/12/12/use-wp_enqueue_scripts-not-wp_print_styles-to-enqueue-scripts-and-styles-for-the-frontend/

https://codex.wordpress.org/Plugin_API/Action_Reference/wp_enqueue_scripts

